### PR TITLE
When removing (or adding) an entry in the combined host file, the contents should update.

### DIFF
--- a/Source/CombinedHostsPredicateController.m
+++ b/Source/CombinedHostsPredicateController.m
@@ -54,10 +54,11 @@
 
 - (IBAction)predicateEditorChanged:(id)sender
 {    
+    [self updateHostsFileContents];
+
     NSInteger newRowCount = [predicateEditor numberOfRows];
     
     if (newRowCount == rowCount) {
-        [self updateHostsFileContents];
         return;
     }
     


### PR DESCRIPTION
Fixes #5.

The size of the view itself isn't updated yet, but at least it now is functional.
Also, when adding multiple new entries, the first is empty (no host file selected) but the ones after the first are already filled with a host entry. Therefore I chose to always update the combined host file content.
