### PR TITLE
Handle host file changes ( not working after vi /etc/hosts )

### DIFF
--- a/Source/HostsMainController.h
+++ b/Source/HostsMainController.h
@@ -74,8 +74,6 @@
 @interface HostsMainController : NSTreeController<HostsControllerDelegateProtocol, VDKQueueDelegate> {
 	@private
 	NSArray *controllers;
-    BOOL trackFileChange;
-	
 	int filesCount;
 }
 


### PR DESCRIPTION
There was a problem whereby VDKQueue wouldn't pick up change events
when I sudo vi /etc/hosts because the file is not just updated,
the file would be removed, then relinked.  So the
'write' change never fired because the underlying file handle
changed.  This change explictly unregisters interest in /etc/hosts
when stopTrackingFileChanges is called and starts watching for change
and delete events when startTrackingFileChanges is called.

To suspend listening, instead of using a boolean, I simply remove
the 'subscription' in VDKQueue.  When i am interested again, we readd
the path which reinitializes the file descriptor.