### PR TITLE
Added El Capitan to supported OS X versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Gas Mask is simple hosts file manager for Mac OS X.
 It allows editing of host files and switching between them.
 
-Runs on Lion, Mountain Lion, Mavericks and Yosemite.
+Runs on Lion, Mountain Lion, Mavericks, Yosemite, and El Capitan.
 
 ## Download
 [Download latest version (0.8.2)](http://gmask.clockwise.ee/files/gas_mask_0.8.2.zip)


### PR DESCRIPTION
I couldn't find any official information on testing required to add an OS X version to the supported list, and it works perfectly fine for me on multiple machines.