### PR TITLE
Use legacy status bar for pre 10.10 - Fixes #73

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: objective-c
 script: xcodebuild ARCHS="i386 x86_64"
+osx_image: xcode7.1

--- a/Preferences.xib
+++ b/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1060" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferenceController">
@@ -14,13 +14,14 @@
                 <outlet property="hotkeysView" destination="106" id="107"/>
                 <outlet property="remoteIntervalSlider" destination="159" id="167"/>
                 <outlet property="remoteView" destination="156" id="157"/>
+                <outlet property="showHostFileNameButton" destination="jeQ-Jp-Iks" id="klK-gR-qYN"/>
                 <outlet property="updateHotkey" destination="170" id="173"/>
                 <outlet property="updateView" destination="47" id="52"/>
                 <outlet property="window" destination="1" id="13"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="1" userLabel="Preferences">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
@@ -131,6 +132,7 @@
                 </button>
             </subviews>
             <animations/>
+            <point key="canvasLocation" x="474" y="443"/>
         </customView>
         <customObject id="58" customClass="SUUpdater"/>
         <customView id="95" userLabel="Editor">

--- a/Source/Menulet.m
+++ b/Source/Menulet.m
@@ -23,10 +23,48 @@
 #import "HostsMainController.h"
 #import "HostsMenu.h"
 #import "Preferences.h"
+#import "Util.h"
 
 @implementation Menulet
 
 - (void)awakeFromNib
+{
+    if ([Util isPre10_10]) {
+        logDebug(@"Initializing Status Bar with pre-Yosemite options");
+        [self awakeFromNibPre10_10];
+    } else {
+        logDebug(@"Initializing Status Bar with Yosemite and later options");
+        [self awakeFromNib10_10AndAfter];
+    }
+}
+/**
+ * OS X 10.10 and later support the NSStatusItemBar button which is what the
+ * "Show Host File Name in Status Bar" feature is built upon.  So if we're
+ * not 10.10 or above, then we need to build the status bar button in the
+ * legacy (pre 10.10) way adn not support the file name in the bar.
+ */
+- (void)awakeFromNibPre10_10
+{
+    statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
+    [statusItem setHighlightMode:YES];
+    [statusItem setEnabled:YES];
+    [statusItem setToolTip:@"Gas Mask"];
+    [statusItem setTitle:@""];
+    [statusItem setAction:@selector(showMenu:)];
+    [statusItem setTarget:self];
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *path = [bundle pathForResource:@"menuIcon" ofType:@"tiff"];
+    NSImage *icon = [[NSImage alloc] initWithContentsOfFile:path];
+    [icon setTemplate:YES];
+    [statusItem setImage:icon];
+}
+/**
+ * Build the status bar using 10.10+ compatible NSStatusBar's button
+ * member.  We also need to add some observers to the preferences so that
+ * we can tear down or re initialize the button if someone changes their
+ * preferences.  
+ */
+- (void)awakeFromNib10_10AndAfter
 {	
     
 	NSBundle *bundle = [NSBundle bundleForClass:[self class]];
@@ -60,11 +98,13 @@
     }
 }
 
+// Only used in 10.10 and above
 -(void) initTitleInBar {
     [statusItem setLength:NSVariableStatusItemLength];
     [[statusItem button] setImagePosition:NSImageLeft];
 }
 
+// Only used in 10.10 and above
 -(void)updateName {
     if (![Preferences showNameInStatusBar]) {
         return;
@@ -73,12 +113,14 @@
     [[statusItem button] setTitle:name];
 }
 
+// Only used in 10.10 and above
 -(void) removeTitleFromBar {
     [statusItem setLength:NSSquareStatusItemLength];
     [[statusItem button] setImagePosition:NSImageOnly];
     [[statusItem button] setTitle:@""];
 }
 
+// Only used in 10.10 and above
 -(void)observeValueForKeyPath:(NSString *)keyPath
                      ofObject:(id)object
                        change:(NSDictionary *)change
@@ -97,11 +139,13 @@
 }
 
 -(void)dealloc {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    [defaults removeObserver:self forKeyPath:ActiveHostsFilePrefKey];
-    [defaults removeObserver:self forKeyPath:ShowNameInStatusBarKey];
+    // we only need clean up if we're 10.10 and above.
+    if (![Util isPre10_10]) {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        [defaults removeObserver:self forKeyPath:ActiveHostsFilePrefKey];
+        [defaults removeObserver:self forKeyPath:ShowNameInStatusBarKey];
+    }
 }
-
 
 -(IBAction)showMenu:(id)sender
 {	

--- a/Source/PreferenceController.h
+++ b/Source/PreferenceController.h
@@ -26,6 +26,8 @@
 	IBOutlet NSView *generalView, *editorView, *hotkeysView, *updateView, *remoteView;
     LoginItem *loginItem;
 	
+    __unsafe_unretained IBOutlet NSButton *showHostFileNameButton;
+    
 	// Remote
 	IBOutlet NSSlider *remoteIntervalSlider;
 	NSDictionary *remoteIntervals;

--- a/Source/PreferenceController.m
+++ b/Source/PreferenceController.m
@@ -25,6 +25,7 @@
 #import "Preferences+Remote.h"
 #import "LoginItem.h"
 #import "Hotkey.h"
+#import "Util.h"
 
 #define TOOLBAR_GENERAL @"TOOLBAR_GENERAL"
 #define TOOLBAR_EDITOR @"TOOLBAR_EDITOR"
@@ -40,6 +41,10 @@
 
 @interface PreferenceController (Hotkeys)
 - (void)initHotkeys;
+@end
+
+@interface PreferenceController (General)
+- (void)initGeneral;
 @end
 
 @implementation PreferenceController
@@ -69,6 +74,7 @@
 	loginItem = [LoginItem new];
 	[loginItem bind:@"enabled" toObject:[Preferences instance] withKeyPath:@"values.openAtLogin" options:nil];
 		
+	[self initGeneral];
 	[self initRemote];
 	[self initHotkeys];
 }
@@ -151,6 +157,18 @@
 	[window setFrame: windowRect display: YES animate: YES];
 }
 
+@end
+
+@implementation PreferenceController (General)
+/**
+ * OS X 10.10 and later support the NSStatusItemBar button which is what the
+ * "Show Host File Name in Status Bar" feature is built upon.  So if we're
+ * not 10.10 or above, then we need to disable the preference selection.
+ */
+- (void) initGeneral
+{
+    showHostFileNameButton.enabled = ![Util isPre10_10];
+}
 @end
 
 @implementation PreferenceController (Remote)

--- a/Source/Util.h
+++ b/Source/Util.h
@@ -21,5 +21,10 @@
 @interface Util : NSObject
 
 + (BOOL) flushDirectoryServiceCache;
-
+/**
+ * OS X 10.10 and later support the NSStatusItemBar button which is what the
+ * "Show Host File Name in Status Bar" feature is built upon.  This method
+ * is a quick way to figure out if we're 10.10 or above.
+ */
++ (BOOL) isPre10_10;
 @end

--- a/Source/Util.m
+++ b/Source/Util.m
@@ -32,4 +32,8 @@
 	return [task terminationStatus] == 0;
 }
 
++ (BOOL) isPre10_10
+{
+    return ( NSAppKitVersionNumber < NSAppKitVersionNumber10_10 );
+}
 @end


### PR DESCRIPTION
1. don't show the active file name in the menu bar if pre 10.10
2. disable the preference button