### PR TITLE
Sort Local hosts when loading

### DIFF
--- a/Source/LocalHostsController.m
+++ b/Source/LocalHostsController.m
@@ -76,6 +76,9 @@
 			}
 			
 			[hostsFiles addObject:hosts];
+            		// grossly sorting array every time we add a host?  Probably there is a better way.
+            		NSSortDescriptor *sort = [NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES];
+            		[hostsFiles sortUsingDescriptors:[NSArray arrayWithObject:sort]];
 		}
 	}
 }


### PR DESCRIPTION
As mentioned in Issues #160 and #140, the list of hosts is not
alphabetized in newer versions of macOS. This change is a feeble
attempt by me to sort the `hostsFiles` array as it's populated.

It seems to have built successfully on my machine but I'm
extremely new to the world of Obj-C development so it would not
surprise me in the least if this does something in a bad or
easily improved way.

That is, I added a way to Sort (`NSSortDescriptor`) and call it
immediately after every time we `addObject` to `hostsFiles` during
`loadFiles` in LocalHostsController.m.

Doing this after every addition seems like it might be a poor
choice from a performance perspective.  Moreover, it may be
wholly unnecessary when used in some environments where this issue
doesn't present.  I went with it anyway because I didn't know how
else to approach this, nor how to conditionally use this logic
only when I know it to be necessary.