### PR TITLE
fix: resolve race condition where editor window sometimes fails to open

### DIFF
--- a/Source/ApplicationController.m
+++ b/Source/ApplicationController.m
@@ -128,7 +128,7 @@ static ApplicationController *sharedInstance = nil;
 	}
 
 	[self showApplicationInDock];
-	[self performSelector:@selector(orderEditorWindowFront) withObject:nil afterDelay:0.1];
+	[self orderEditorWindowFront];
 }
 
 - (IBAction)closeEditorWindow:(id)sender
@@ -205,7 +205,9 @@ static ApplicationController *sharedInstance = nil;
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication
 {
 	shouldQuit = YES;
-	[self hideApplicationFromDock];
+	if (!editorWindowOpened) {
+		[self hideApplicationFromDock];
+	}
 	return NO;
 }
 
@@ -307,9 +309,6 @@ static ApplicationController *sharedInstance = nil;
 
 - (void)hideApplicationFromDock
 {
-	[NSObject cancelPreviousPerformRequestsWithTarget:self
-											 selector:@selector(orderEditorWindowFront)
-											   object:nil];
 	[NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
 	[Preferences setShowEditorWindow:NO];
 	[[NSNotificationCenter defaultCenter] removeObserver:self

--- a/Tests/GasMaskTests/ApplicationControllerTests.m
+++ b/Tests/GasMaskTests/ApplicationControllerTests.m
@@ -26,9 +26,6 @@
 
 - (void)closeEditorWindowForTesting
 {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self
-                                             selector:@selector(orderEditorWindowFront)
-                                               object:nil];
     NSWindow *w = [self editorWindowForTesting];
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                      name:NSWindowWillCloseNotification


### PR DESCRIPTION
## Summary

- Fix intermittent bug where clicking "Show Editor Window" from the status bar menu does nothing
- Root cause: `openEditorWindow:` used `performSelector:afterDelay:0.1` to show the window, creating a 100ms race window during which `applicationShouldTerminateAfterLastWindowClosed:` could fire and cancel the pending show via `hideApplicationFromDock`
- Replace the delayed perform with a synchronous call and guard the delegate method against interfering when the editor is open

## Test plan

- [ ] Click "Show Editor Window" from status bar — window appears reliably
- [ ] Close via close button (red X) — dock icon hides
- [ ] Click "Show Editor Window" again — window reappears (re-open path)
- [ ] Close via Cmd+W — dock icon hides
- [ ] Open Preferences while editor is open, close Preferences — editor stays, dock icon stays
- [ ] Close editor, immediately click "Show Editor Window" — window appears