### PR TITLE
fix: active indicator not updating when activating hosts file

### DIFF
--- a/Gas Mask.xcodeproj/project.pbxproj
+++ b/Gas Mask.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		AA000014000000000000AAAA /* HostsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000013000000000000AAAA /* HostsRowView.swift */; };
 		AA000016000000000000AAAA /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000015000000000000AAAA /* SidebarView.swift */; };
 		AA00001A000000000000AAAA /* HostsDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000019000000000000AAAA /* HostsDataStoreTests.swift */; };
+		AA000022000000000000AAAA /* HostsRowViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000021000000000000AAAA /* HostsRowViewTests.swift */; };
 		EE000002000000000000EE01 /* EditorWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE000001000000000000EE01 /* EditorWindowPresenterTests.swift */; };
 		AA00001C000000000000AAAA /* HostsTextViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001B000000000000AAAA /* HostsTextViewRepresentable.swift */; };
 		AA00001E000000000000AAAA /* CombinedHostsPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001D000000000000AAAA /* CombinedHostsPickerView.swift */; };
@@ -299,6 +300,7 @@
 		AA000013000000000000AAAA /* HostsRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HostsRowView.swift; path = "Source/Swift/HostsRowView.swift"; sourceTree = "<group>"; };
 		AA000015000000000000AAAA /* SidebarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SidebarView.swift; path = "Source/Swift/SidebarView.swift"; sourceTree = "<group>"; };
 		AA000019000000000000AAAA /* HostsDataStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostsDataStoreTests.swift; sourceTree = "<group>"; };
+		AA000021000000000000AAAA /* HostsRowViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostsRowViewTests.swift; sourceTree = "<group>"; };
 		EE000001000000000000EE01 /* EditorWindowPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorWindowPresenterTests.swift; sourceTree = "<group>"; };
 		AA00001B000000000000AAAA /* HostsTextViewRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HostsTextViewRepresentable.swift; path = "Source/Swift/HostsTextViewRepresentable.swift"; sourceTree = "<group>"; };
 		AA00001D000000000000AAAA /* CombinedHostsPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CombinedHostsPickerView.swift; path = "Source/Swift/CombinedHostsPickerView.swift"; sourceTree = "<group>"; };
@@ -788,6 +790,7 @@
 				AA00000D000000000000AAAA /* URLSheetPresenterTests.swift */,
 				AA00000F000000000000AAAA /* URLSheetViewTests.swift */,
 				AA000019000000000000AAAA /* HostsDataStoreTests.swift */,
+				AA000021000000000000AAAA /* HostsRowViewTests.swift */,
 				EE000001000000000000EE01 /* EditorWindowPresenterTests.swift */,
 								BB00000D000000000000BBBB /* RemoteIntervalMapperTests.swift */,
 								BB00000F000000000000BBBB /* SparkleObserverTests.swift */,
@@ -1071,6 +1074,7 @@
 				AA00000E000000000000AAAA /* URLSheetPresenterTests.swift in Sources */,
 				AA000010000000000000AAAA /* URLSheetViewTests.swift in Sources */,
 				AA00001A000000000000AAAA /* HostsDataStoreTests.swift in Sources */,
+				AA000022000000000000AAAA /* HostsRowViewTests.swift in Sources */,
 				EE000002000000000000EE01 /* EditorWindowPresenterTests.swift in Sources */,
 				BB00000E000000000000BBBB /* RemoteIntervalMapperTests.swift in Sources */,
 				BB000010000000000000BBBB /* SparkleObserverTests.swift in Sources */,

--- a/Source/Swift/HostsRowView.swift
+++ b/Source/Swift/HostsRowView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct HostsRowView: View {
     let hosts: Hosts
     let isGroup: Bool
+    // Unused in body; exists to invalidate SwiftUI's byte-comparison cache when Hosts properties change.
+    let refreshToken: UInt64
 
     var body: some View {
         if isGroup {
@@ -106,6 +108,10 @@ struct HostsRowView: View {
     // MARK: - Accessibility
 
     private var accessibilityDescription: String {
+        Self.accessibilityDescription(for: hosts)
+    }
+
+    static func accessibilityDescription(for hosts: Hosts) -> String {
         var parts: [String] = []
         parts.append(hosts.name() ?? "")
         if hosts.active() { parts.append("active") }

--- a/Source/Swift/SidebarView.swift
+++ b/Source/Swift/SidebarView.swift
@@ -13,7 +13,7 @@ struct SidebarView: View {
         List(selection: $store.selectedHosts) {
             ForEach(store.hostsGroups, id: \.self) { group in
                 let children = (group.children as? [Hosts]) ?? []
-                Section(header: HostsRowView(hosts: group, isGroup: true)) {
+                Section(header: HostsRowView(hosts: group, isGroup: true, refreshToken: store.rowRefreshToken)) {
                     ForEach(children, id: \.self) { hosts in
                         rowContent(for: hosts)
                             .tag(hosts)
@@ -59,7 +59,7 @@ struct SidebarView: View {
         if isEditing, store.renamingHosts === hosts {
             renameField(for: hosts)
         } else {
-            HostsRowView(hosts: hosts, isGroup: false)
+            HostsRowView(hosts: hosts, isGroup: false, refreshToken: store.rowRefreshToken)
                 .draggable(hosts.contents() ?? "") {
                     Text(hosts.name() ?? "")
                 }

--- a/Tests/GasMaskTests/HostsDataStoreTests.swift
+++ b/Tests/GasMaskTests/HostsDataStoreTests.swift
@@ -76,4 +76,46 @@ final class HostsDataStoreTests: XCTestCase {
 
         XCTAssertFalse(store.isBusy)
     }
+
+    // MARK: - Row Refresh Token
+
+    func testRowRefreshToken_incrementsOnHostsNodeNeedsUpdate() {
+        let store = HostsDataStore()
+        let before = store.rowRefreshToken
+
+        NotificationCenter.default.post(name: .hostsNodeNeedsUpdate, object: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        XCTAssertEqual(store.rowRefreshToken, before &+ 1)
+    }
+
+    func testRowRefreshToken_incrementsOnHostsFileSaved() {
+        let store = HostsDataStore()
+        let before = store.rowRefreshToken
+
+        NotificationCenter.default.post(name: .hostsFileSaved, object: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        XCTAssertEqual(store.rowRefreshToken, before &+ 1)
+    }
+
+    func testRowRefreshToken_incrementsOnSynchronizingStatusChanged() {
+        let store = HostsDataStore()
+        let before = store.rowRefreshToken
+
+        NotificationCenter.default.post(name: .synchronizingStatusChanged, object: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        XCTAssertEqual(store.rowRefreshToken, before &+ 1)
+    }
+
+    func testRowRefreshToken_doesNotChangeOnUnrelatedNotification() {
+        let store = HostsDataStore()
+        let before = store.rowRefreshToken
+
+        NotificationCenter.default.post(name: .hostsFileCreated, object: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        XCTAssertEqual(store.rowRefreshToken, before)
+    }
 }

--- a/Tests/GasMaskTests/HostsRowViewTests.swift
+++ b/Tests/GasMaskTests/HostsRowViewTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Gas_Mask
+
+final class HostsRowViewTests: XCTestCase {
+
+    private var tempFilePath: String!
+
+    override func setUp() {
+        super.setUp()
+        let tempDir = NSTemporaryDirectory()
+        tempFilePath = (tempDir as NSString).appendingPathComponent("RowTestHosts.hst")
+        try? "127.0.0.1 localhost".write(toFile: tempFilePath, atomically: true, encoding: .utf8)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: tempFilePath)
+        super.tearDown()
+    }
+
+    // MARK: - Accessibility Description
+
+    func testAccessibilityDescription_activeHost_includesActive() {
+        let hosts = Hosts(path: tempFilePath)!
+        hosts.setActive(true)
+
+        let description = HostsRowView.accessibilityDescription(for: hosts)
+
+        XCTAssertTrue(description.contains("active"))
+    }
+
+    func testAccessibilityDescription_inactiveHost_excludesActive() {
+        let hosts = Hosts(path: tempFilePath)!
+        // Default state is inactive
+
+        let description = HostsRowView.accessibilityDescription(for: hosts)
+
+        XCTAssertFalse(description.contains("active"))
+    }
+
+    func testAccessibilityDescription_unsavedHost_includesUnsaved() {
+        let hosts = Hosts(path: tempFilePath)!
+        hosts.setContents("# modified")
+
+        let description = HostsRowView.accessibilityDescription(for: hosts)
+
+        XCTAssertTrue(description.contains("unsaved"))
+    }
+
+    func testAccessibilityDescription_updatesAfterActiveChange() {
+        let hosts = Hosts(path: tempFilePath)!
+
+        let before = HostsRowView.accessibilityDescription(for: hosts)
+        XCTAssertFalse(before.contains("active"), "precondition")
+
+        hosts.setActive(true)
+        let after = HostsRowView.accessibilityDescription(for: hosts)
+        XCTAssertTrue(after.contains("active"))
+    }
+}


### PR DESCRIPTION
## Summary

- Fix sidebar active indicator (green dot) not moving when activating a different hosts file
- Replace broken `self.hostsGroups = self.hostsGroups` self-assignment with a `rowRefreshToken` counter that invalidates SwiftUI's byte-comparison cache
- Add 8 new tests covering the refresh token behavior and row accessibility output

## Root Cause

`HostsRowView` is a SwiftUI struct with a `Hosts` reference (ObjC `NSObject` subclass). When `setActive:` mutates the object in-place, the pointer stays the same. SwiftUI compares view structs byte-by-byte and skips re-rendering when the bytes are identical — so `hosts.active()` was never re-called after activation.

## Approach

Add `@Published private(set) var rowRefreshToken: UInt64` to `HostsDataStore` that increments on every row-property notification. Pass this token into `HostsRowView` as a struct field. When the token changes, the struct bytes change, SwiftUI re-evaluates `body`, and `hosts.active()` returns the correct value.

## Test plan

- [x] `rowRefreshToken` increments on `hostsNodeNeedsUpdate` notification
- [x] `rowRefreshToken` increments on `hostsFileSaved` notification  
- [x] `rowRefreshToken` increments on `synchronizingStatusChanged` notification
- [x] `rowRefreshToken` does NOT change on unrelated notifications
- [x] Active hosts file row includes "active" in accessibility label
- [x] Inactive hosts file row excludes "active" from accessibility label
- [x] Unsaved hosts file row includes "unsaved" in accessibility label
- [x] Accessibility description updates after active state change
- [ ] Manual: activate hosts file → green dot moves to new file
- [ ] Manual: toolbar Activate button disables after activation